### PR TITLE
Added MetaData to Basket Poco

### DIFF
--- a/src/UmbCheckout.Core/Pocos/UmbCheckoutBasket.cs
+++ b/src/UmbCheckout.Core/Pocos/UmbCheckoutBasket.cs
@@ -39,6 +39,6 @@ namespace UmbCheckout.Core.Pocos
         [Column("MetaData")]
         [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         [NullSetting(NullSetting = NullSettings.Null)]
-        public Dictionary<string, string>? MetaData { get; set; }
+        public string? MetaData { get; set; }
     }
 }

--- a/src/UmbCheckout.Core/Pocos/UmbCheckoutBasket.cs
+++ b/src/UmbCheckout.Core/Pocos/UmbCheckoutBasket.cs
@@ -35,5 +35,10 @@ namespace UmbCheckout.Core.Pocos
         [Column("LastUpdatedDateTime")]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         public DateTime? LastUpdatedDateTime { get; set; } = DateTime.Now;
+        
+        [Column("MetaData")]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public Dictionary<string, string>? MetaData { get; set; }
     }
 }


### PR DESCRIPTION
This PR added the MetaData property to the UmbCheckoutBasket Poco class.

Please note that I've not been able to test this locally as I'm not sure how to get the repo up and running, but based on how that class is being used, I think this is all that should be needed.

I've also branched off of the `main` branch, rather than `develop`, as it looks like `develop` still needs updating since the last release.